### PR TITLE
Add AccountController and AccountService

### DIFF
--- a/src/main/java/org/example/accountservice/controller/AccountController.java
+++ b/src/main/java/org/example/accountservice/controller/AccountController.java
@@ -1,0 +1,28 @@
+package org.example.accountservice.controller;
+
+import org.example.accountservice.dto.AccountDto;
+import org.example.accountservice.service.AccountService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping(path = "/api/accounts", produces = { MediaType.APPLICATION_JSON_VALUE })
+public class AccountController {
+  private final AccountService accountService;
+
+  @Autowired
+  public AccountController(AccountService accountService) {
+    this.accountService = accountService;
+  }
+
+  @GetMapping
+  public ResponseEntity<List<AccountDto>> getAllAccounts() {
+    return ResponseEntity.ok(accountService.getAllAccounts());
+  }
+}

--- a/src/main/java/org/example/accountservice/service/AccountService.java
+++ b/src/main/java/org/example/accountservice/service/AccountService.java
@@ -1,0 +1,40 @@
+package org.example.accountservice.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.example.accountservice.dto.AccountDto;
+import org.example.accountservice.entity.Account;
+import org.example.accountservice.repository.AccountRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+public class AccountService {
+  private final AccountRepository accountRepository;
+
+  @Autowired
+  public AccountService(AccountRepository accountRepository) {
+    this.accountRepository = accountRepository;
+  }
+
+  public List<AccountDto> getAllAccounts() {
+    List<Account> accounts = accountRepository.findAll();
+
+    log.info("Get accounts : {}", accounts);
+
+    return accounts.stream()
+            .map(this::convertToDto)
+            .collect(Collectors.toList());
+  }
+
+  private AccountDto convertToDto(Account account) {
+    return new AccountDto(
+            account.getAccountNumber(),
+            account.getAccountType(),
+            account.getBranchAddress()
+    );
+  }
+}


### PR DESCRIPTION
### Description:
This pull request introduces a new AccountController and AccountService for managing account-related operations.

### Changes:

#### AccountController:
- **AccountController:** Added a new REST controller class responsible for handling account-related HTTP requests.
 - Annotated with `@RestController` and `@RequestMapping` to map the "/api/accounts" URL path.
 - Includes a `@GetMapping` method that returns a list of `AccountDto` objects representing all accounts.
 - Injected with an `AccountService` instance via constructor-based dependency injection.

#### AccountService:
- **AccountService:** Added a new service class responsible for providing business logic related to account operations.
 - Annotated with `@Service` to mark it as a service component.
 - Injected with an `AccountRepository` instance via constructor-based dependency injection.
 - Includes the `getAllAccounts()` method that retrieves all accounts from the repository, converts them to `AccountDto` objects, and returns a list of `AccountDto` objects.
 - Includes the `convertToDto()` private helper method that converts an `Account` entity to an `AccountDto` object.

### Purpose:
The purpose of this pull request is to introduce the necessary controller and service components for managing account-related opera