### PR TITLE
Refactor AccountService `getAllAccounts` method to use AccountMapper

### DIFF
--- a/src/main/java/org/example/accountservice/service/AccountService.java
+++ b/src/main/java/org/example/accountservice/service/AccountService.java
@@ -3,6 +3,7 @@ package org.example.accountservice.service;
 import lombok.extern.slf4j.Slf4j;
 import org.example.accountservice.dto.AccountDto;
 import org.example.accountservice.entity.Account;
+import org.example.accountservice.mapper.AccountMapper;
 import org.example.accountservice.repository.AccountRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -26,15 +27,7 @@ public class AccountService {
     log.info("Get accounts : {}", accounts);
 
     return accounts.stream()
-            .map(this::convertToDto)
+            .map(AccountMapper::mapToAccountDto)
             .collect(Collectors.toList());
-  }
-
-  private AccountDto convertToDto(Account account) {
-    return new AccountDto(
-            account.getAccountNumber(),
-            account.getAccountType(),
-            account.getBranchAddress()
-    );
   }
 }


### PR DESCRIPTION
### Description:
This pull request refactors the `AccountService` class to use the `AccountMapper` class for mapping between `Account` and `AccountDto` objects.

### Changes:
- **Imported `AccountMapper` class:** The `AccountService` class now imports the `AccountMapper` class to utilize its mapping functionalities.

- **Replaced method references:** The `convertToDto` method in the `getAllAccounts` method of `AccountService` has been replaced with `AccountMapper.mapToAccountDto` method references.

- **Removed redundant method:** The `convertToDto` method implementation has been removed from the `AccountService` class.

### Purpose:
The purpose of this pull request is to enhance the `AccountService` class by delegating the responsibility of mapping between `Account` and `AccountDto` objects to the dedicated `AccountMapper` class. This refactoring improves code readability, maintainability, and separation of concerns within the codebase.
