### PR TITLE
Refactor CustomerService getAllCustomers method to use CustomerMapper

### DIFF
--- a/src/main/java/org/example/accountservice/service/CustomerService.java
+++ b/src/main/java/org/example/accountservice/service/CustomerService.java
@@ -3,6 +3,7 @@ package org.example.accountservice.service;
 import lombok.extern.slf4j.Slf4j;
 import org.example.accountservice.dto.CustomerDto;
 import org.example.accountservice.entity.Customer;
+import org.example.accountservice.mapper.CustomerMapper;
 import org.example.accountservice.repository.CustomerRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -26,15 +27,7 @@ public class CustomerService {
     log.info("Get customers : {}", customers);
 
     return customers.stream()
-            .map(this::convertToDto)
+            .map(CustomerMapper::mapToCustomerDto)
             .collect(Collectors.toList());
-  }
-
-  private CustomerDto convertToDto(Customer customer) {
-    return new CustomerDto(
-            customer.getName(),
-            customer.getEmail(),
-            customer.getMobileNumber()
-    );
   }
 }


### PR DESCRIPTION
### Description:
This pull request refactors the `CustomerService` class to use the `CustomerMapper` for mapping between `Customer` and `CustomerDto` objects.

### Changes:
- **Refactor CustomerService:** Updated the `CustomerService` class to import and use the `CustomerMapper` for object mapping.
- **Method Replacement:** Replaced the `convertToDto` method with `CustomerMapper.mapToCustomerDto` within the `getAllCustomers` method.
- **Method Removal:** Removed the `convertToDto` method implementation from the `CustomerService` class.

### Purpose:
The purpose of this pull request is to improve code maintainability and readability by centralizing the mapping logic within the dedicated `CustomerMapper` class, resulting in cleaner and more focused service methods.
