### PR TITLE
Update account number from String to Long

### DIFF
--- a/src/main/java/org/example/accountservice/dto/AccountDto.java
+++ b/src/main/java/org/example/accountservice/dto/AccountDto.java
@@ -1,7 +1,7 @@
 package org.example.accountservice.dto;
 
 public record AccountDto(
-        String accountNumber,
+        Long accountNumber,
         String accountType,
         String branchAddress
 ) {

--- a/src/main/java/org/example/accountservice/entity/Account.java
+++ b/src/main/java/org/example/accountservice/entity/Account.java
@@ -14,8 +14,8 @@ public class Account extends Audit {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Column(unique = true, nullable = false, length = 20)
-  private String accountNumber;
+  @Column(unique = true, nullable = false)
+  private Long accountNumber;
 
   @Column(nullable = false, length = 100)
   private String accountType;

--- a/src/test/java/org/example/accountservice/mapper/AccountMapperTest.java
+++ b/src/test/java/org/example/accountservice/mapper/AccountMapperTest.java
@@ -11,7 +11,7 @@ public class AccountMapperTest {
   void testMapToAccountDto() {
     // Given
     Account account = new Account();
-    account.setAccountNumber("ACC001");
+    account.setAccountNumber(10000000L);
     account.setAccountType("Savings");
     account.setBranchAddress("123 Main St, City");
 
@@ -19,7 +19,7 @@ public class AccountMapperTest {
     AccountDto accountDto = AccountMapper.mapToAccountDto(account);
 
     // Then
-    assertEquals("ACC001", accountDto.accountNumber());
+    assertEquals(10000000L, accountDto.accountNumber());
     assertEquals("Savings", accountDto.accountType());
     assertEquals("123 Main St, City", accountDto.branchAddress());
   }
@@ -27,13 +27,13 @@ public class AccountMapperTest {
   @Test
   void testMapToAccount() {
     // Given
-    AccountDto accountDto = new AccountDto("ACC001", "Savings", "123 Main St, City");
+    AccountDto accountDto = new AccountDto(10000000L, "Savings", "123 Main St, City");
 
     // When
     Account account = AccountMapper.mapToAccount(accountDto);
 
     // Then
-    assertEquals("ACC001", account.getAccountNumber());
+    assertEquals(10000000L, account.getAccountNumber());
     assertEquals("Savings", account.getAccountType());
     assertEquals("123 Main St, City", account.getBranchAddress());
   }


### PR DESCRIPTION
### Description:
This pull request introduces a refactoring to change the data type of the `accountNumber` field from `String` to `Long` in the `AccountDto` record and the `Account` entity class.

### Changes:
 - Changes the data type of the `accountNumber` field from `String` to `Long` in the `AccountDto` record and the `Account` entity class.
 - Updates the `AccountMapperTest` class to use `Long` values for the `accountNumber` field in the test cases.

### Purpose:
The purpose of this pull request is to improve the data representation and handling of account numbers by using a more appropriate data type (`Long`) instead of `String`. Using a numeric data type like `Long` can provide better performance, easier manipulation, and more efficient storage for account numbers, which are typically represented as large integers.

This refactoring aims to enhance the overall code quality, maintainability, and performance by leveraging the appropriate data types for the respective use cases. It ensures consistency in handling account numbers throughout the application and aligns with best practices for data modeling.