### PR TITLE
Rename ErrorResponse to ErrorResponseDto and modify errorCode to Http…

### DIFF
--- a/src/main/java/org/example/accountservice/dto/ErrorResponseDto.java
+++ b/src/main/java/org/example/accountservice/dto/ErrorResponseDto.java
@@ -1,10 +1,12 @@
 package org.example.accountservice.dto;
 
+import org.springframework.http.HttpStatus;
+
 import java.time.LocalDateTime;
 
-public record ErrorResponse(
+public record ErrorResponseDto(
         String apiPath,
-        String errorCode,
+        HttpStatus errorCode,
         String errorMessage,
         LocalDateTime errorTimestamp
 ) {


### PR DESCRIPTION
### Description:
This pull request introduces refactoring changes to the `ErrorResponse` class, renaming it to `ErrorResponseDto` and modifying the `errorCode` field to use the `HttpStatus` enum.

### Changes:
 - Renames the `ErrorResponse` record to `ErrorResponseDto` for better naming consistency.
 - Changes the `errorCode` field from `String` to `HttpStatus` to represent the HTTP status code of the error response.

### Purpose:
The purpose of this pull request is to improve the naming convention and structure of the error response DTO (Data Transfer Object) class. By renaming `ErrorResponse` to `ErrorResponseDto`, it aligns with the common naming convention for DTO classes, making it more readable and consistent within the codebase.

Additionally, changing the `errorCode` field from `String` to `HttpStatus` provides a more structured and type-safe representation of HTTP status codes. Using the `HttpStatus` enum instead of a plain string ensures better maintainability, readability, and potential IDE assistance (e.g., autocompletion, validation) when working with HTTP status codes in the application.

This refactoring enhances the overall code quality, consistency, and developer experience when dealing with error responses and HTTP status codes within the application.