### PR TITLE
Add AccountConstants enum

### DIFF
--- a/src/main/java/constants/AccountConstants.java
+++ b/src/main/java/constants/AccountConstants.java
@@ -1,0 +1,28 @@
+package constants;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum AccountConstants {
+  // Account Types
+  SAVINGS("Savings"),
+
+  // Address
+  ADDRESS("ABC Street, Mumbai"),
+
+  // HTTP Status Codes
+  STATUS_201("201"),
+  STATUS_200("200"),
+  STATUS_500("500"),
+
+  // Success Messages
+  MESSAGE_201("Account created successfully"),
+  MESSAGE_200("Request processed successfully"),
+
+  // Error Messages
+  MESSAGE_500("An error occurred. Please try again later");
+
+  private final String value;
+}


### PR DESCRIPTION
### Description:
This pull request introduces a new enum `AccountConstants` to manage constants related to account types, addresses, HTTP status codes, success messages, and error messages.

### Changes:
- `AccountConstants` enum: Encapsulates account-related constants including `SAVINGS` account type, `ADDRESS` string, HTTP status codes (`STATUS_201`, `STATUS_200`, `STATUS_500`), and success/error messages (`MESSAGE_201`, `MESSAGE_200`, `MESSAGE_500`).

### Purpose:
The purpose of this pull request is to centralize and manage account-related constants within the `AccountConstants` enum, improving code readability and maintainability.
