### PR TITLE
Add private constructor to AccountMapper and CustomerMapper classes

### DIFF
--- a/src/main/java/org/example/accountservice/mapper/AccountMapper.java
+++ b/src/main/java/org/example/accountservice/mapper/AccountMapper.java
@@ -4,6 +4,13 @@ import org.example.accountservice.dto.AccountDto;
 import org.example.accountservice.entity.Account;
 
 public class AccountMapper {
+  /**
+   * Private constructor to hide the implicit public one
+   */
+  private AccountMapper() {
+    throw new IllegalStateException("Utility class");
+  }
+
   public static AccountDto mapToAccountDto(Account account) {
     return new AccountDto(
             account.getAccountNumber(),

--- a/src/main/java/org/example/accountservice/mapper/CustomerMapper.java
+++ b/src/main/java/org/example/accountservice/mapper/CustomerMapper.java
@@ -4,6 +4,13 @@ import org.example.accountservice.dto.CustomerDto;
 import org.example.accountservice.entity.Customer;
 
 public class CustomerMapper {
+  /**
+   * Private constructor to hide the implicit public one
+   */
+  private CustomerMapper() {
+    throw new IllegalStateException("Utility class");
+  }
+
   public static CustomerDto mapToCustomerDto(Customer customer) {
     return new CustomerDto(
             customer.getName(),


### PR DESCRIPTION
### Description:
This pull request introduces changes to the AccountMapper and CustomerMapper classes to prevent instantiation of these utility classes.

### Changes:
- **Add private constructor to AccountMapper and CustomerMapper classes:** Added a private constructor to both the `AccountMapper` and `CustomerMapper` classes, which throws an `IllegalStateException` with the message `Utility class` if an attempt is made to instantiate these classes.

### Purpose:
The purpose of this pull request is to enforce the intended usage of the AccountMapper and CustomerMapper classes, which are designed to be used as utility classes with static methods. By adding a private constructor and throwing an exception if an attempt is made to instantiate the class, it ensures that these classes are used correctly and prevents potential misuse or unintended behavior that could arise from creating instances of these classes.

This change follows the principle of making utility classes non-instantiable, which is a best practice in object-oriented programming. It helps maintain the integrity of the codebase and prevents potential issues related to class instantiation, such as resource leaks or unexpected side effects.