### PR TITLE
Refactor AccountMapperTest and CustomerMapperTest class modifier to package-private

### DIFF
--- a/src/test/java/org/example/accountservice/mapper/AccountMapperTest.java
+++ b/src/test/java/org/example/accountservice/mapper/AccountMapperTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class AccountMapperTest {
+class AccountMapperTest {
   @Test
   void testMapToAccountDto() {
     // Given

--- a/src/test/java/org/example/accountservice/mapper/CustomerMapperTest.java
+++ b/src/test/java/org/example/accountservice/mapper/CustomerMapperTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class CustomerMapperTest {
+class CustomerMapperTest {
   @Test
   void testMapToCustomerDto() {
     // Given


### PR DESCRIPTION
### Description:
This pull request introduces refactoring changes to make the AccountMapperTest and CustomerMapperTest classes package-private by changing their access modifiers.

### Changes:
- **Refactor AccountMapperTest class modifier to package-private:** Changed the access modifier of the `AccountMapperTest` class from public to package-private by removing the 'public' keyword.

- **Refactor CustomerMapperTest class modifier to package-private:** Changed the access modifier of the `CustomerMapperTest` class from public to package-private by removing the 'public' keyword.

### Purpose:
The purpose of this pull request is to follow the principle of least privilege and encapsulation by restricting the visibility of the `AccountMapperTest` and `CustomerMapperTest` classes to only within the same package. Since unit tests are typically used within the same package as the code they are testing, making these test classes package-private ensures that they are not unintentionally accessed or instantiated from outside the package.

By making these test classes package-private, the codebase adheres to best practices for access modifiers and encapsulation. It helps maintain a cleaner codebase by limiting the exposure of classes and their members to the minimum required scope, reducing the risk of unintended access or modifications from outside the intended scope.