### PR TITLE
Refactor AccountService to use Customer ID instead of Customer object

### DIFF
--- a/src/main/java/org/example/accountservice/service/AccountService.java
+++ b/src/main/java/org/example/accountservice/service/AccountService.java
@@ -52,7 +52,7 @@ public class AccountService {
 
     Customer customer = mapAndSaveCustomer(customerDto);
 
-    Account account = createAccountForCustomer(customer);
+    Account account = createAccountForCustomer(customer.getId());
 
     accountRepository.save(account);
   }
@@ -85,13 +85,13 @@ public class AccountService {
    * Creates a new Account entity for the given Customer.
    * Generates a random account number and sets other account details.
    *
-   * @param customer The Customer entity for which the account is being created.
+   * @param customerId The Customer id for which the account is being created.
    * @return The newly created Account entity.
    */
-  private Account createAccountForCustomer(Customer customer) {
+  private Account createAccountForCustomer(Long customerId) {
     Long accountNumber = generateRandomAccountNumber();
 
-    return buildAccount(accountNumber, customer);
+    return buildAccount(accountNumber, customerId);
   }
 
   /**
@@ -107,16 +107,16 @@ public class AccountService {
    * Builds an Account entity with the given account number and associated Customer.
    *
    * @param accountNumber The account number to set for the Account entity.
-   * @param customer      The Customer entity to associate with the Account.
+   * @param customerId      The Customer id to associate with the Account.
    * @return The built Account entity.
    */
-  private Account buildAccount(Long accountNumber, Customer customer) {
+  private Account buildAccount(Long accountNumber, Long customerId) {
     Account account = new Account();
 
     account.setAccountNumber(accountNumber);
     account.setAccountType(AccountConstants.SAVINGS.getValue());
     account.setBranchAddress(AccountConstants.ADDRESS.getValue());
-    account.setCustomerId(customer.getId());
+    account.setCustomerId(customerId);
 
     return account;
   }


### PR DESCRIPTION
### Description:
This pull request introduces refactoring changes to the AccountService class to decouple it from the Customer domain object and utilize only the Customer ID instead.

### Changes:
- **Refactor AccountService to use Customer ID instead of Customer object:** Modified the `createAccountForCustomer` method to accept a `customerId` (Long) instead of a `Customer` object. Updated the `buildAccount` method to accept a `customerId` (Long) instead of a `Customer` object. Changed the method call in the `createAccount` method to pass `customer.getId()` instead of the entire `Customer` object.

### Purpose:
The purpose of this pull request is to reduce the coupling between the AccountService and the Customer domain object by utilizing only the Customer ID instead of the entire Customer object. This change adheres to the principle of loose coupling, making the AccountService less dependent on the implementation details of the Customer class.

By decoupling the AccountService from the Customer object, this refactoring improves the maintainability and flexibility of the codebase. Modifications to the Customer class would have less impact on the AccountService, as the AccountService only relies on the Customer ID, which is less likely to change. This change promotes better separation of concerns and makes it easier to evolve or refactor the Customer class independently without affecting the AccountService.