### PR TITLE
Add AccountNumber custom validator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,10 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/org/example/accountservice/validation/AccountNumber.java
+++ b/src/main/java/org/example/accountservice/validation/AccountNumber.java
@@ -1,0 +1,18 @@
+package org.example.accountservice.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = { AccountNumberValidator.class })
+@Target({ ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AccountNumber {
+  String message() default "Account number must be exactly 10 digits";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/org/example/accountservice/validation/AccountNumberValidator.java
+++ b/src/main/java/org/example/accountservice/validation/AccountNumberValidator.java
@@ -1,0 +1,11 @@
+package org.example.accountservice.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class AccountNumberValidator implements ConstraintValidator<AccountNumber, Long> {
+  @Override
+  public boolean isValid(Long aLong, ConstraintValidatorContext constraintValidatorContext) {
+    return aLong != null && String.valueOf(aLong).length() == 10;
+  }
+}


### PR DESCRIPTION
### Description:
This pull request introduces a custom validation annotation `@AccountNumber` and its corresponding validator implementation to ensure that certain fields in the application conform to the requirement of being a 10-digit number.

### Changes:
- **Added spring-boot-starter-validation dependency:** Added the `spring-boot-starter-validation` dependency to the project's `pom.xml` file, which provides the Jakarta Bean Validation API and its integration with Spring Boot.

- **Created validation package:** Created a new package `org.example.accountservice.validation` to hold custom validation annotations and validators.

- **Added @AccountNumber annotation:** Introduced a new custom validation annotation `@AccountNumber` in the `AccountNumber.java` file. This annotation can be applied to fields that need to be validated as 10-digit numbers.

- **Implemented AccountNumberValidator:** Created the `AccountNumberValidator.java` file, which implements the `ConstraintValidator` interface for the `@AccountNumber` annotation. The `isValid` method checks if the input value is not null and its string representation has a length of 10 characters.

### Purpose:
The purpose of this pull request is to enhance the validation capabilities of the application by introducing a custom validation rule for fields that should contain 10-digit numbers. This will help ensure data integrity and provide meaningful validation errors to users when invalid input is provided.