### PR TITLE
Add custom exception handling for validation errors

### DIFF
--- a/src/main/java/org/example/accountservice/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/example/accountservice/exception/GlobalExceptionHandler.java
@@ -1,16 +1,23 @@
 package org.example.accountservice.exception;
 
+import lombok.NonNull;
 import org.example.accountservice.dto.ErrorResponseDto;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
 
 @ControllerAdvice
-public class GlobalExceptionHandler {
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
   @ExceptionHandler(Exception.class)
   public ResponseEntity<ErrorResponseDto> handleGlobalException(
           Exception exception,
@@ -54,5 +61,20 @@ public class GlobalExceptionHandler {
     );
 
     return new ResponseEntity<>(errorResponseDto, HttpStatus.NOT_FOUND);
+  }
+
+  @Override
+  protected ResponseEntity<Object> handleMethodArgumentNotValid(
+          @NonNull MethodArgumentNotValidException exception,
+          @NonNull HttpHeaders headers,
+          @NonNull HttpStatusCode status,
+          @NonNull WebRequest webRequest
+  ) {
+    Map<String, String> errors = new HashMap<>();
+
+    exception.getBindingResult().getFieldErrors().forEach(error ->
+            errors.put(error.getField(), error.getDefaultMessage()));
+
+    return new ResponseEntity<>(errors, HttpStatus.BAD_REQUEST);
   }
 }


### PR DESCRIPTION
### Description:
This pull request introduces custom exception handling for validation errors in the application, allowing for structured error responses containing field names and corresponding error messages when validation fails for request bodies or method parameters.

### Changes:
- **Add custom validation error handling:** Extended the `GlobalExceptionHandler` class to inherit from `ResponseEntityExceptionHandler` and override the `handleMethodArgumentNotValid` method to handle `MethodArgumentNotValidException` exceptions.
- **Create structured error response:** Inside the `handleMethodArgumentNotValid` method, created a `Map<String, String>` to store field errors and their corresponding error messages. Iterated over the `FieldError` objects from the `BindingResult` of the exception and added each field name and error message to the `errors` map.
- **Return error response:** Returned a `ResponseEntity` with the `errors` map as the response body and an HTTP status of `BAD_REQUEST`.

### Purpose:
The purpose of this pull request is to improve the error handling capabilities of the application when dealing with validation errors. By providing a structured error response containing field names and corresponding error messages, it becomes easier for client applications to identify and display validation errors to users. This enhancement improves the overall user experience and helps in troubleshooting and debugging issues related to invalid input data.