### PR TITLE
Implement JPA auditing for entities with AuditorAware

### DIFF
--- a/src/main/java/org/example/accountservice/AccountServiceApplication.java
+++ b/src/main/java/org/example/accountservice/AccountServiceApplication.java
@@ -2,8 +2,10 @@ package org.example.accountservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing(auditorAwareRef = "auditAwareImpl")
 public class AccountServiceApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/org/example/accountservice/AccountServiceApplication.java
+++ b/src/main/java/org/example/accountservice/AccountServiceApplication.java
@@ -5,7 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EnableJpaAuditing(auditorAwareRef = "auditAwareImpl")
+@EnableJpaAuditing(auditorAwareRef = "auditorAwareImpl")
 public class AccountServiceApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/org/example/accountservice/audit/AuditorAwareImpl.java
+++ b/src/main/java/org/example/accountservice/audit/AuditorAwareImpl.java
@@ -1,0 +1,16 @@
+package org.example.accountservice.audit;
+
+import lombok.NonNull;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component(value = "auditAwareImpl")
+public class AuditorAwareImpl implements AuditorAware<String> {
+  @Override
+  @NonNull
+  public Optional<String> getCurrentAuditor() {
+    return Optional.of("system");
+  }
+}

--- a/src/main/java/org/example/accountservice/audit/AuditorAwareImpl.java
+++ b/src/main/java/org/example/accountservice/audit/AuditorAwareImpl.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.Optional;
 
-@Component(value = "auditAwareImpl")
+@Component(value = "auditorAwareImpl")
 public class AuditorAwareImpl implements AuditorAware<String> {
   @Override
   @NonNull

--- a/src/main/java/org/example/accountservice/entity/Audit.java
+++ b/src/main/java/org/example/accountservice/entity/Audit.java
@@ -22,11 +22,11 @@ import java.time.LocalDateTime;
 public abstract class Audit {
   @CreatedDate
   @Column(updatable = false, nullable = false)
-  private LocalDateTime createdAt = LocalDateTime.now();
+  private LocalDateTime createdAt;
 
   @CreatedBy
   @Column(updatable = false, nullable = false, length = 20)
-  private String createdBy = "system";
+  private String createdBy;
 
   @LastModifiedDate
   @Column(insertable = false)


### PR DESCRIPTION
### Description:
This pull request introduces auditing support for entities in the application, enabling automatic population and management of `createdAt`, `createdBy`, `updatedAt`, and `updatedBy` fields when creating or updating entities.

### Changes:
- **Implement JPA auditing for entities:** Enabled JPA auditing in the `AccountServiceApplication` class by adding the `@EnableJpaAuditing` annotation with the `auditorAwareRef` attribute set to `"auditorAwareImpl"`.
- **Add auditing package:** Created a new package `org.example.accountservice.audit` for auditing-related components.
- **Implement AuditorAwareImpl:** Added an `AuditorAwareImpl` class that implements the `AuditorAware` interface to provide the current auditor (user) information. This class is annotated with `@Component(value = "auditorAwareImpl")` to be recognized as the auditor provider for JPA auditing.
- **Modify Audit abstract class:** Modified the `Audit` abstract class to remove the default values for `createdAt` and `createdBy` fields, allowing them to be automatically populated by the JPA auditing mechanism.

### Purpose:
The purpose of this pull request is to enhance the application's data management capabilities by introducing auditing support for entities. By automatically populating and managing the `createdAt`, `createdBy`, `updatedAt`, and `updatedBy` fields, the application can maintain a comprehensive audit trail for entity changes, improving data integrity and providing valuable information for auditing and troubleshooting purposes.