### PR TITLE
Add OpenAPI Documentation Configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.5.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/org/example/accountservice/AccountServiceApplication.java
+++ b/src/main/java/org/example/accountservice/AccountServiceApplication.java
@@ -1,11 +1,30 @@
 package org.example.accountservice;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Contact;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.info.License;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing(auditorAwareRef = "auditorAwareImpl")
+@OpenAPIDefinition(
+        info = @Info(
+                title = "Account Service API",
+                version = "1.0.0",
+                description = "API documentation for the Account Service",
+                contact = @Contact(
+                        name = "Aamir Shaikh",
+                        email = "aamir.email@example.com"
+                ),
+                license = @License(
+                        name = "Apache 2.0",
+                        url = "https://www.apache.org/licenses/LICENSE-2.0"
+                )
+        )
+)
 public class AccountServiceApplication {
 
   public static void main(String[] args) {


### PR DESCRIPTION
### Description:
This pull request introduces the initial configuration for OpenAPI documentation to the project.

### Changes:
- **Dependency:** Added `springdoc-openapi-starter-webmvc-ui` to `pom.xml` to enable generation of OpenAPI documentation.
- **Annotation:** Added `@OpenAPIDefinition` to the `AccountServiceApplication` class to provide metadata about the API, including title, version, description, contact information, and license details.

### Purpose:
The purpose of this pull request is to enable the generation of comprehensive OpenAPI documentation for the Account Service API, facilitating easier understanding and integration for developers.
