### PR TITLE
Add OpenAPI documentation for DTOs

### DIFF
--- a/src/main/java/org/example/accountservice/dto/AccountCustomerDto.java
+++ b/src/main/java/org/example/accountservice/dto/AccountCustomerDto.java
@@ -1,13 +1,20 @@
 package org.example.accountservice.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 
+@Schema(
+        name = "AccountCustomer",
+        description = "Represents account and customer details"
+)
 public record AccountCustomerDto(
+        @Schema(description = "Account details")
         @NotNull(message = "Account details are required")
         @Valid
         AccountDto accountDto,
 
+        @Schema(description = "Customer details")
         @NotNull(message = "Customer details are required")
         @Valid
         CustomerDto customerDto

--- a/src/main/java/org/example/accountservice/dto/AccountDto.java
+++ b/src/main/java/org/example/accountservice/dto/AccountDto.java
@@ -1,19 +1,27 @@
 package org.example.accountservice.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import org.example.accountservice.validation.AccountNumber;
 
+@Schema(
+        name = "Account",
+        description = "Represents account details"
+)
 public record AccountDto(
+        @Schema(description = "Account number", example = "1234567890")
         @NotNull(message = "Account number is required")
         @AccountNumber(message = "Account number must be exactly 10 digits")
         Long accountNumber,
 
+        @Schema(description = "Account type", example = "Savings")
         @NotBlank(message = "Account type is required")
         @Size(max = 100, message = "Account type cannot exceed 100 characters")
         String accountType,
 
+        @Schema(description = "Branch address", example = "123 Main St, Anytown USA")
         @NotBlank(message = "Branch address is required")
         @Size(max = 200, message = "Branch address cannot exceed 200 characters")
         String branchAddress

--- a/src/main/java/org/example/accountservice/dto/CustomerDto.java
+++ b/src/main/java/org/example/accountservice/dto/CustomerDto.java
@@ -1,20 +1,28 @@
 package org.example.accountservice.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
+@Schema(
+        name = "Customer",
+        description = "Represents customer details"
+)
 public record CustomerDto(
+        @Schema(description = "Customer name", example = "John Doe")
         @NotBlank(message = "Name is required")
         @Size(max = 100, message = "Name cannot exceed 100 characters")
         String name,
 
+        @Schema(description = "Customer email", example = "john.doe@example.com")
         @NotBlank(message = "Email is required")
         @Email(message = "Invalid email format")
         @Size(max = 100, message = "Email cannot exceed 100 characters")
         String email,
 
+        @Schema(description = "Customer mobile number", example = "1234567890")
         @NotBlank(message = "Mobile number is required")
         @Pattern(regexp = "^\\d{10}$", message = "Mobile number must be exactly 10 digits")
         String mobileNumber

--- a/src/main/java/org/example/accountservice/dto/ErrorResponseDto.java
+++ b/src/main/java/org/example/accountservice/dto/ErrorResponseDto.java
@@ -1,13 +1,25 @@
 package org.example.accountservice.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.springframework.http.HttpStatus;
 
 import java.time.LocalDateTime;
 
+@Schema(
+        name = "ErrorResponse",
+        description = "Represents an error response"
+)
 public record ErrorResponseDto(
+        @Schema(description = "API path")
         String apiPath,
+
+        @Schema(description = "Error code")
         HttpStatus errorCode,
+
+        @Schema(description = "Error message")
         String errorMessage,
+
+        @Schema(description = "Error timestamp")
         LocalDateTime errorTimestamp
 ) {
 }

--- a/src/main/java/org/example/accountservice/dto/ResponseDto.java
+++ b/src/main/java/org/example/accountservice/dto/ResponseDto.java
@@ -1,7 +1,16 @@
 package org.example.accountservice.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(
+        name = "Response",
+        description = "Represents a success response"
+)
 public record ResponseDto(
+        @Schema(description = "Status code")
         String statusCode,
+
+        @Schema(description = "Status message")
         String statusMessage
 ) {
 }


### PR DESCRIPTION
### Description:
This pull request introduces OpenAPI documentation annotations to the DTOs (Data Transfer Objects) in the account-service module.

### Changes:
- **Add OpenAPI documentation annotations to DTOs:** Added OpenAPI annotations using the `@Schema` and related annotations to the AccountCustomerDto, AccountDto, CustomerDto, ErrorResponseDto, and ResponseDto classes. These annotations provide descriptions and examples for the fields in the DTOs.

### Purpose:
The purpose of this pull request is to enhance the API documentation and improve the developer experience. By adding OpenAPI annotations, the API documentation can be automatically generated, making it easier for developers to understand and consume the API. Clear and comprehensive documentation is essential for maintainability and facilitating collaboration within the development team.